### PR TITLE
v4: structural eval grading via monocle spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ Architecture-first skill lifecycle: design → build → test → evaluate → p
 Most skill tools jump straight to "write SKILL.md." Conductor makes you choose the architecture first - because rewriting a wrong pattern costs more than writing it right.
 
 <details>
+<summary><strong>v4: Structural eval grading via monocle spans</strong></summary>
+
+See the [Structural eval grading](#structural-eval-grading-monocle) section below. Adds `structural_assertions` to the `evals.json` schema, `monocle_runner.py` + `structural_grader.py` to shared scripts, and `references/monocle_tracing.md` as the author guide.
+
+</details>
+
+<details>
 <summary><strong>v3: SOP practices + smoke tests</strong></summary>
 
 - **`references/sop-practices.md`** — 80 years of Standard Operating Procedure wisdom applied to skill authoring. Inline checklists at risk-points, pre-flight checks, programmatic validation, exception handling patterns. Use for procedural skills (client intake, onboarding, reporting, escalation)
@@ -68,26 +75,49 @@ Choose before writing a single line:
 ## Eval infrastructure
 
 ```
-                    ┌─────────┐
-                    │  SKILL  │
-                    └────┬────┘
-                         │
-              ┌──────────┼──────────┐
-              │          │          │
-         ┌────▼────┐ ┌──▼───┐ ┌───▼────┐
-         │ Grader  │ │ A/B  │ │Analyzer│
-         │         │ │Blind │ │        │
-         │assertions│ │compare│ │root    │
-         │+ claims │ │      │ │cause   │
-         └─────────┘ └──────┘ └────────┘
-              │          │          │
-              └──────────┼──────────┘
-                         │
-                   ┌─────▼─────┐
-                   │ Benchmark │
-                   │ mean±std  │
-                   └───────────┘
+                       ┌─────────┐
+                       │  SKILL  │
+                       └────┬────┘
+                            │
+        ┌──────────┬────────┼────────┬──────────┐
+        │          │        │        │          │
+   ┌────▼────┐ ┌──▼───┐ ┌──▼─────┐ ┌─▼────────┐
+   │ Grader  │ │ A/B  │ │Analyzer│ │Structural│
+   │         │ │Blind │ │        │ │ (monocle │
+   │assertions│ │compare│ │ root  │ │ spans,   │
+   │+ claims │ │      │ │ cause  │ │ optional)│
+   └─────────┘ └──────┘ └────────┘ └──────────┘
+        │          │        │           │
+        └──────────┴────┬───┴───────────┘
+                       │
+                 ┌─────▼─────┐
+                 │ Benchmark │
+                 │ mean±std  │
+                 └───────────┘
 ```
+
+## Structural eval grading (monocle)
+
+Some eval requirements live only inside execution — which version of a maintained policy applied, exact internal call counts, version-pinned operations — and aren't recoverable from output files. NL grading reads transcripts and outputs; it can't satisfy assertions about those facts. [Monocle](https://github.com/monocle2ai/monocle) emits spans from bundled scripts at runtime; the structural grader reads them and verifies deterministically.
+
+**Test prompt** (verifies the integration via `test-skills/pii-scrubber/`):
+
+> "Redact PII from `evals/fixtures/customer_calls.json` and save the result to `/tmp/pii_scrub_eval/clean.json`. The file is going to an external vendor."
+
+The eval declares `denylist_version == "v3"` and `redacted_count >= 8` as structural assertions. Without monocle: 1/5 structural assertions pass — the output file carries no policy version, and counting `[REDACTED:*]` tags in the file gives surviving tags, not the scrubber's authoritative internal counter. With monocle: 5/5 pass — both facts arrive as span attributes emitted by the wrapper.
+
+**Why monocle:** policy version, internal counters, exact call counts, and span ordering are knowable only at runtime inside the wrapped code. Monocle is the channel that gets them out to the grader without modifying the user's script.
+
+**When to use:** the eval needs to assert on internal execution state not visible in the output file.
+
+**When NOT to use:** pure-Markdown skills · scripts where any equivalent code would be equally correct · evals fully expressible via output-file `expectations`. No `monocle.yaml` → structural grader returns `skipped: true` with zero overhead.
+
+**Minimum opt-in (3 files per skill):**
+1. `monocle.yaml` — declare wrappers + `output_processor: "_processors:NAME"` reference
+2. `scripts/_processors.py` — accessor lambdas returning span attribute values as strings (no OpenTelemetry imports in the skill)
+3. `scripts/_run.sh` — conditional launcher; transparent in production, threads monocle in eval mode
+
+See `skills/skill-conductor/references/monocle_tracing.md` for the author guide.
 
 ## Installation
 
@@ -105,7 +135,8 @@ skills/
     ├── references/
     │   ├── patterns.md
     │   ├── schemas.md
-    │   └── sop-practices.md
+    │   ├── sop-practices.md
+    │   └── monocle_tracing.md
     ├── assets/
     │   └── eval_review.html
     └── scripts/
@@ -116,6 +147,8 @@ skills/
         ├── improve_description.py
         ├── aggregate_benchmark.py
         ├── generate_report.py
+        ├── monocle_runner.py
+        ├── structural_grader.py
         ├── package_skill.py
         ├── quick_validate.py
         ├── test_smoke.py

--- a/skills/skill-conductor/SKILL.md
+++ b/skills/skill-conductor/SKILL.md
@@ -114,6 +114,8 @@ Choose degrees of freedom — this determines how much control vs. flexibility t
 
 **Если скил процедурный** (бизнес-процесс с цепочкой действий и решениями: обработка заявки, создание КП, обработка счёта, онбординг, эскалация инцидента) — прочитай `references/sop-practices.md`. Там 8 принципов из 80-летней SOP-традиции (армия США → авиация → McDonald's): TWI-структура шагов, inline-чеклисты, 5 Why, выбор формата (simple/hierarchical/flowchart), запреты на модальные слова. Это сильно меняет как пишется SKILL.md для процедурных задач.
 
+**If the eval needs to assert on internal execution state that isn't recoverable from output files** (which denylist version applied, exact internal call counts, version-pinned operations) — read `references/monocle_tracing.md`. Add `structural_assertions` to `evals.json` and ship a `monocle.yaml`. Do NOT add monocle when the skill is pure Markdown, when bundled scripts are convenience-only, or when the eval's quality bar is fully expressible from output files — the LLM grader is sufficient and adding monocle is overhead with no signal.
+
 ### Step 4: Scaffold
 
 ```bash
@@ -465,6 +467,7 @@ Creates `skill-name.skill` (zip with .skill extension). Verify: unzip in temp di
 | `references/patterns.md`         | 5 architectural patterns + anti-patterns   |
 | `references/schemas.md`          | JSON schemas for evals, grading, benchmark |
 | `references/sop-practices.md`    | 8 SOP principles for procedural skills (TWI, 5 Why, format selection, modal weasel words) |
+| `references/monocle_tracing.md`  | Structural eval grading via monocle spans — for skills bundling correctness-critical scripts |
 | `eval-viewer/`                   | Interactive HTML viewer for eval results   |
 | `assets/eval_review.html`        | Trigger eval set editor                    |
 | `scripts/eval_skill.py`          | Structural validation (10-point scoring)   |

--- a/skills/skill-conductor/references/monocle_tracing.md
+++ b/skills/skill-conductor/references/monocle_tracing.md
@@ -1,0 +1,211 @@
+# Monocle Structural Tracing for Skills
+
+Some eval requirements cannot be checked from output files alone. Which version of a maintained denylist applied · the exact internal redaction counter · whether a version-pinned helper was called rather than an inline equivalent — those facts live only inside the running code. NL grading reads transcripts and outputs; it cannot recover them. Monocle emits spans from the bundled scripts at runtime so the structural grader can assert on them deterministically.
+
+## When to opt in
+
+Add monocle ONLY when both apply:
+
+1. The skill bundles a Python script encoding correctness-critical behavior (version pins, maintained denylists, idempotency, ordering).
+2. The eval needs to assert on an internal execution fact (call count, attribute value, span ordering) that is **not** recoverable from output files.
+
+## When NOT to use
+
+- Pure-Markdown skills.
+- Skills where the bundled script is convenience-only and any equivalent code would be equally correct.
+- Evals whose quality bar is fully expressible via `expectations` (file content, transcript narration). The LLM grader is sufficient; monocle adds wiring with no signal.
+
+When you skip, drop `monocle.yaml` and omit `structural_assertions` from `evals.json`. The structural grader returns `skipped: true` with zero overhead.
+
+## What you add
+
+Three files per skill that opts in:
+
+```
+<skill>/
+├── monocle.yaml                 # wrapper spec (this is the opt-in signal)
+├── scripts/_run.sh              # launcher that conditionally invokes monocle
+└── evals/evals.json             # gains a structural_assertions field per eval
+```
+
+## monocle.yaml format
+
+```yaml
+workflow_name: pii-scrubber          # optional, defaults to skill folder name
+wrappers:
+  - package: scripts.scrub           # Python module path relative to skill root
+    object: ""                       # empty for module-level functions; class name otherwise
+    method: scrub_file               # function name to wrap
+    span_name: pii.scrub_file        # name structural_assertions will match on
+    span_type: workflow              # optional — "workflow" marks the root span
+```
+
+One entry per function you want assertable. Keep span names stable — assertions reference them by exact match.
+
+## Launcher pattern (`scripts/_run.sh`)
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SC_DIR="${SKILL_CONDUCTOR_DIR:-$HOME/.zeroclaw/workspace/skills/skill-conductor}"
+
+if [ -n "${MONOCLE_TRACE_OUTPUT_PATH:-}" ] && [ -f "$SKILL_DIR/monocle.yaml" ]; then
+    exec uv run "$SC_DIR/scripts/monocle_runner.py" --config "$SKILL_DIR/monocle.yaml" "$@"
+else
+    exec uv run "$@"
+fi
+```
+
+Skill instructs the agent to call bundled scripts via `scripts/_run.sh scripts/scrub.py ...`. When `MONOCLE_TRACE_OUTPUT_PATH` is unset (production, normal use), the launcher is transparent — no monocle overhead, no extra processes. The eval harness sets the env var only when running evals.
+
+## structural_assertions in evals.json
+
+Add a `structural_assertions` array alongside the existing `expectations`:
+
+```json
+{
+  "id": 1,
+  "prompt": "Redact /tmp/customer_calls.json and write to /tmp/clean.json",
+  "expectations": ["No emails appear in /tmp/clean.json"],
+  "structural_assertions": [
+    {"kind": "span_present", "name": "pii.scrub_file"},
+    {"kind": "span_attribute", "name": "pii.scrub_file", "key": "denylist_version", "op": "==", "value": "v3"}
+  ]
+}
+```
+
+### Assertion kinds
+
+| Kind | Required keys | Passes when |
+|---|---|---|
+| `span_present` | `name` | At least one span with this name was emitted |
+| `span_absent` | `name` | No span with this name was emitted |
+| `span_count` | `name`, `op`, `value` | Span count satisfies the comparison |
+| `span_attribute` | `name`, `key`, `op`, `value` | At least one matching span has an attribute satisfying the comparison |
+| `span_order` | `before`, `after` | Latest `before.end_time` ≤ earliest `after.start_time` |
+| `no_error_spans` | — | No span has status_code == ERROR |
+
+Operators: `==`, `!=`, `>`, `>=`, `<`, `<=`.
+
+## How the eval harness invokes it
+
+When running an eval for a skill that has `monocle.yaml`:
+
+1. Create `<run_dir>/spans/` and export `MONOCLE_TRACE_OUTPUT_PATH=<run_dir>/spans/`
+2. Spawn the executor as normal
+3. After the executor finishes, run:
+
+```bash
+uv run scripts/structural_grader.py \
+    --spans-dir <run_dir>/spans \
+    --assertions <skill>/evals/evals.json \
+    --eval-id <id> \
+    --output <run_dir>/structural.json
+```
+
+4. `aggregate_benchmark.py` merges `structural.json` into `benchmark.json` under a `structural` key per run
+
+When `monocle.yaml` is absent, step 1 is skipped, step 3 is also skipped, and `aggregate_benchmark.py` simply doesn't add a `structural` key. The viewer's structural column shows "—" for those runs.
+
+## Wrapping a function — minimal example
+
+`scripts/scrub.py`:
+
+```python
+def scrub_file(input_path: str, output_path: str, denylist_version: str = "v3") -> int:
+    # ... actual scrubbing ...
+    return redacted_count
+```
+
+`monocle.yaml`:
+
+```yaml
+workflow_name: pii-scrubber
+wrappers:
+  - package: scripts.scrub
+    object: ""
+    method: scrub_file
+    span_name: pii.scrub_file
+    span_type: workflow
+```
+
+eval entry:
+
+```json
+{
+  "kind": "span_present",
+  "name": "pii.scrub_file"
+}
+```
+
+After running, monocle writes `<run_dir>/spans/monocle_trace_pii-scrubber_<traceid>_<ts>.json`. The structural grader matches `pii.scrub_file` and reports pass.
+
+## Adding attributes to spans
+
+Span attributes are declared via monocle's `output_processor` pattern — a Python dict of accessor lambdas that read function args/kwargs/return value. Keep this in a sidecar `.py` file next to your script so user code stays free of OTel imports.
+
+### Why not call `trace.set_attribute` from inside the function?
+
+Monocle isolates user spans from instrumentation spans by default, so `trace.get_current_span()` inside the wrapped function returns a NonRecordingSpan — attributes are silently dropped. The escape hatch (`MONOCLE_ISOLATE_SPANS=false`) is bugged in monocle 0.8.4. Use `output_processor`.
+
+### Pattern
+
+`scripts/_processors.py`:
+
+```python
+SCRUB_FILE_PROCESSOR = {
+    "type": "workflow",
+    "attributes": [[
+        {"attribute": "denylist_version", "accessor": lambda a: read_version(a["args"][0])},
+        {"attribute": "input_path",       "accessor": lambda a: str(a["args"][0])},
+        {"attribute": "redacted_count",   "accessor": lambda a: str(a["result"]),
+         "phase": "post_execution"},
+    ]],
+}
+```
+
+`monocle.yaml`:
+
+```yaml
+wrappers:
+  - package: scrub
+    method: scrub_file
+    span_name: pii.scrub_file
+    span_type: workflow
+    output_processor: "_processors:SCRUB_FILE_PROCESSOR"
+```
+
+### Accessor contract
+
+Each accessor receives an `arguments` dict:
+
+```python
+{
+    "instance": <self or None>,
+    "args":     <positional args tuple>,
+    "kwargs":   <kwargs dict>,
+    "result":   <return value — only available when phase == "post_execution">,
+    "parent_span": <parent Span>,
+    "span":     <current Span>,
+}
+```
+
+Two important rules:
+
+1. **Accessor return values MUST be `str` or `list`.** Monocle drops other types silently. Stringify ints/floats/bools; the structural grader's `span_attribute` coerces numeric strings back to numbers for comparisons.
+2. **Use `"phase": "post_execution"` for accessors that read `result`.** Without it, the accessor runs before the function executes and `result` is `None`.
+
+### How attributes appear on the span
+
+Monocle prefixes every user-declared attribute as `entity.<N>.<your_name>`, where N is a per-span counter. The structural grader auto-strips this prefix — `{"kind": "span_attribute", "key": "denylist_version"}` matches `entity.1.denylist_version` without you having to write the prefix.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `structural.json` says `skipped: true` with "no spans directory" | Launcher didn't invoke monocle_runner.py | Check `MONOCLE_TRACE_OUTPUT_PATH` is exported before the executor spawns |
+| Spans dir exists but is empty | Wrapper package can't be imported | Ensure `package:` field in monocle.yaml matches actual import path; check spaces/typos |
+| Span present but attribute always None | The wrapped function isn't setting attributes via the OTel API | Add `span.set_attribute(...)` calls inside the function |
+| Assertion fails despite obvious-correct behavior | Span name in assertion doesn't match `span_name:` in monocle.yaml | Verify exact string match — case-sensitive, no whitespace |

--- a/skills/skill-conductor/references/schemas.md
+++ b/skills/skill-conductor/references/schemas.md
@@ -17,7 +17,10 @@ Defines the evals for a skill. Located at `evals/evals.json` within the skill di
       "prompt": "User's example prompt",
       "expected_output": "Description of expected result",
       "files": ["evals/files/sample1.pdf"],
-      "expectations": ["The output includes X", "The skill used script Y"]
+      "expectations": ["The output includes X", "The skill used script Y"],
+      "structural_assertions": [
+        {"kind": "span_present", "name": "pii.scrub_file"}
+      ]
     }
   ]
 }
@@ -30,7 +33,8 @@ Defines the evals for a skill. Located at `evals/evals.json` within the skill di
 - `evals[].prompt`: The task to execute
 - `evals[].expected_output`: Human-readable description of success
 - `evals[].files`: Optional list of input file paths (relative to skill root)
-- `evals[].expectations`: List of verifiable statements
+- `evals[].expectations`: List of verifiable statements (NL, graded by `agents/grader.md`)
+- `evals[].structural_assertions`: Optional. Deterministic assertions over monocle spans, graded by `scripts/structural_grader.py`. Use ONLY when the eval needs to verify internal execution state that's not recoverable from output files (denylist version applied, exact internal call counts, version pins). When the eval can be fully expressed via `expectations`, omit this field. When omitted, the structural grader returns `skipped: true` with zero overhead. See `references/monocle_tracing.md`.
 
 ---
 

--- a/skills/skill-conductor/scripts/monocle_runner.py
+++ b/skills/skill-conductor/scripts/monocle_runner.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "monocle_apptrace>=0.8.4",
+#   "pyyaml>=6.0",
+# ]
+# ///
+"""Run a target Python script under monocle instrumentation.
+
+Reads a monocle.yaml spec, registers custom wrapper_methods, sets up the
+file exporter, then exec's the target script via runpy with its argv
+preserved. Returns the target script's exit code.
+
+Usage:
+    monocle_runner.py --config <skill>/monocle.yaml <target.py> [args...]
+
+Environment:
+    MONOCLE_TRACE_OUTPUT_PATH  Directory for span JSON files (required to enable tracing)
+    MONOCLE_WORKFLOW_NAME      Optional service-name override; defaults to skill folder name
+
+When MONOCLE_TRACE_OUTPUT_PATH is unset, this still runs the target — but
+without instrumentation overhead. The launcher decides whether to invoke
+this wrapper at all; the wrapper itself doesn't enforce opt-in.
+
+monocle.yaml format (subset of WrapperMethod fields):
+
+    workflow_name: pii-scrubber   # optional, defaults to MONOCLE_WORKFLOW_NAME or script name
+    wrappers:
+      - package: scripts.scrub
+        object: ""
+        method: scrub_file
+        span_name: pii.scrub_file
+        span_type: workflow
+"""
+
+import argparse
+import importlib
+import os
+import sys
+from pathlib import Path
+
+
+def load_config(path: Path) -> dict:
+    import yaml
+    return yaml.safe_load(path.read_text()) or {}
+
+
+def _resolve_processor(ref: str):
+    """Resolve a 'module:ATTR' reference to a Python object.
+
+    The module is imported via importlib; ATTR is fetched by getattr.
+    Used for output_processor so the user can declare attribute extractors
+    in a sidecar .py file (lambdas can't live in YAML).
+    """
+    if not ref:
+        return None
+    if ":" not in ref:
+        raise ValueError(f"output_processor must be 'module:ATTR', got {ref!r}")
+    module_name, attr = ref.split(":", 1)
+    module = importlib.import_module(module_name)
+    return getattr(module, attr)
+
+
+def to_wrapper_methods(wrappers: list[dict]) -> list:
+    """Translate our compact YAML form into monocle WrapperMethod objects.
+
+    Using WrapperMethod objects (not raw dicts) ensures the default
+    `task_wrapper` callable is attached — raw dicts pass through to the
+    instrumentor as-is and its `wrapped_by(...)` call fails when
+    `wrapper_method` is missing.
+    """
+    from monocle_apptrace.instrumentation.common.wrapper_method import WrapperMethod
+    out = []
+    for w in wrappers:
+        out.append(WrapperMethod(
+            package=w["package"],
+            object_name=w.get("object", ""),
+            method=w["method"],
+            span_name=w.get("span_name"),
+            span_type=w.get("span_type"),
+            output_processor=_resolve_processor(w.get("output_processor")),
+        ))
+    return out
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--config", required=True, type=Path)
+    args, rest = parser.parse_known_args()
+
+    if not rest or not rest[0].endswith(".py"):
+        print("Usage: monocle_runner.py --config <yaml> <target.py> [args...]", file=sys.stderr)
+        return 2
+
+    target = Path(rest[0]).resolve()
+    target_argv = rest
+
+    config = load_config(args.config)
+    workflow_name = (
+        config.get("workflow_name")
+        or os.environ.get("MONOCLE_WORKFLOW_NAME")
+        or target.stem
+    )
+
+    # Path setup MUST happen before to_wrapper_methods — it resolves
+    # `output_processor: "module:ATTR"` references via importlib, and
+    # those modules typically live next to the target script.
+    skill_root = args.config.resolve().parent
+    if str(skill_root) not in sys.path:
+        sys.path.insert(0, str(skill_root))
+    target_dir = str(target.parent)
+    if target_dir not in sys.path:
+        sys.path.insert(0, target_dir)
+
+    wrapper_methods = to_wrapper_methods(config.get("wrappers", []))
+
+    # Lazy import so a missing dependency surfaces with a clear error
+    # message at the launcher level rather than at module import.
+    from monocle_apptrace import setup_monocle_telemetry
+
+    setup_monocle_telemetry(
+        workflow_name=workflow_name,
+        wrapper_methods=wrapper_methods,
+        monocle_exporters_list="file",
+        union_with_default_methods=False,
+    )
+
+    # Import the target as a real module so the wrapped function IS the
+    # one that runs. runpy.run_path would execute it as __main__, which is
+    # a separate module object and would bypass the wrappers.
+    sys.argv = target_argv
+    module_name = target.stem
+    module = importlib.import_module(module_name)
+    if not hasattr(module, "main"):
+        print(f"target module '{module_name}' has no main() function", file=sys.stderr)
+        return 2
+    try:
+        result = module.main()
+        return result if isinstance(result, int) else 0
+    except SystemExit as e:
+        return e.code if isinstance(e.code, int) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/skill-conductor/scripts/structural_grader.py
+++ b/skills/skill-conductor/scripts/structural_grader.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# ///
+"""Deterministic structural grader for monocle-instrumented skill runs.
+
+Reads spans emitted by monocle's FileSpanExporter (one JSON file per trace
+in MONOCLE_TRACE_OUTPUT_PATH), evaluates a list of structural assertions
+from evals.json, and writes a JSON result.
+
+Usage:
+    structural_grader.py \\
+        --spans-dir <run-dir>/spans \\
+        --assertions <skill>/evals/evals.json \\
+        --eval-id 1 \\
+        --output <run-dir>/structural.json
+
+If the spans dir is missing or empty, the grader writes a result with
+skipped=true rather than failing — this is the graceful no-op path for
+skills that don't opt into monocle tracing.
+
+Assertion grammar (each entry in evals[].structural_assertions):
+
+    {kind: "span_present", name: "pii.scrub_file"}
+    {kind: "span_absent",  name: "pii.scrub_file"}
+    {kind: "span_count",   name: "pii.scrub_file", op: ">=", value: 1}
+    {kind: "span_attribute", name: "pii.scrub_file", key: "denylist_version", op: "==", value: "v3"}
+    {kind: "span_order",   before: "validate.run", after: "deploy.run"}
+    {kind: "no_error_spans"}
+
+`name` matches against the span's `name` field. Attributes are looked up
+inside `span.attributes`. Comparisons use standard Python operators on the
+extracted value.
+"""
+
+import argparse
+import glob
+import json
+import operator
+import sys
+from pathlib import Path
+from typing import Any
+
+
+OPS = {
+    "==": operator.eq,
+    "!=": operator.ne,
+    ">":  operator.gt,
+    ">=": operator.ge,
+    "<":  operator.lt,
+    "<=": operator.le,
+}
+
+
+def load_spans(spans_dir: Path) -> list[dict]:
+    """Load every span from every monocle_trace_*.json in the directory.
+
+    monocle's FileSpanExporter writes one JSON file per trace. Each file
+    contains either a single span dict or a list of span dicts depending
+    on flush timing. We accept both.
+    """
+    spans: list[dict] = []
+    if not spans_dir.is_dir():
+        return spans
+    for path in sorted(spans_dir.glob("monocle_trace_*.json")):
+        try:
+            data = json.loads(path.read_text())
+        except json.JSONDecodeError:
+            continue
+        if isinstance(data, list):
+            spans.extend(data)
+        elif isinstance(data, dict):
+            spans.append(data)
+    return spans
+
+
+def find_spans(spans: list[dict], name: str) -> list[dict]:
+    return [s for s in spans if s.get("name") == name]
+
+
+def get_attribute(span: dict, key: str) -> Any:
+    """Return the span attribute matching `key`.
+
+    Monocle output_processors store attributes under `entity.<N>.<key>`
+    where N is a per-span counter. We accept either the exact key or any
+    `entity.*.<key>` suffix match.
+    """
+    attrs = span.get("attributes", {}) or {}
+    if key in attrs:
+        return attrs[key]
+    suffix = f".{key}"
+    for k, v in attrs.items():
+        if k.startswith("entity.") and k.endswith(suffix):
+            return v
+    return None
+
+
+def _coerce_for_compare(value: Any, target: Any) -> Any:
+    """If target is numeric and value is a numeric string, coerce.
+
+    monocle requires accessor return values to be str or list, so authors
+    stringify ints. Numeric assertions still want to compare as numbers.
+    """
+    if isinstance(value, str) and isinstance(target, (int, float)):
+        try:
+            return type(target)(value) if "." in value or isinstance(target, float) else int(value)
+        except ValueError:
+            return value
+    return value
+
+
+def evaluate(assertion: dict, spans: list[dict]) -> dict:
+    kind = assertion.get("kind")
+
+    if kind == "span_present":
+        matches = find_spans(spans, assertion["name"])
+        return {
+            "passed": len(matches) > 0,
+            "evidence": f"found {len(matches)} span(s) named '{assertion['name']}'",
+        }
+
+    if kind == "span_absent":
+        matches = find_spans(spans, assertion["name"])
+        return {
+            "passed": len(matches) == 0,
+            "evidence": f"found {len(matches)} span(s) named '{assertion['name']}' (expected 0)",
+        }
+
+    if kind == "span_count":
+        matches = find_spans(spans, assertion["name"])
+        op = OPS[assertion["op"]]
+        ok = op(len(matches), assertion["value"])
+        return {
+            "passed": ok,
+            "evidence": f"count={len(matches)} {assertion['op']} {assertion['value']}",
+        }
+
+    if kind == "span_attribute":
+        matches = find_spans(spans, assertion["name"])
+        if not matches:
+            return {"passed": False, "evidence": f"no span named '{assertion['name']}'"}
+        key, want, op = assertion["key"], assertion["value"], OPS[assertion["op"]]
+        raw_values = [get_attribute(s, key) for s in matches]
+        coerced = [_coerce_for_compare(v, want) for v in raw_values]
+        ok = any(v is not None and op(v, want) for v in coerced)
+        return {
+            "passed": ok,
+            "evidence": f"attribute '{key}' values={raw_values}, expected {assertion['op']} {want}",
+        }
+
+    if kind == "span_order":
+        before = find_spans(spans, assertion["before"])
+        after = find_spans(spans, assertion["after"])
+        if not before or not after:
+            return {
+                "passed": False,
+                "evidence": f"missing spans: before={len(before)} after={len(after)}",
+            }
+        b_end = min(s.get("end_time", "") for s in before)
+        a_start = min(s.get("start_time", "") for s in after)
+        return {
+            "passed": b_end <= a_start,
+            "evidence": f"before ends at {b_end}, after starts at {a_start}",
+        }
+
+    if kind == "no_error_spans":
+        errored = [s for s in spans if (s.get("status") or {}).get("status_code") == "ERROR"]
+        return {
+            "passed": len(errored) == 0,
+            "evidence": f"{len(errored)} error span(s)",
+        }
+
+    return {"passed": False, "evidence": f"unknown assertion kind: {kind!r}"}
+
+
+def load_assertions(path: Path, eval_id: int | None) -> list[dict]:
+    data = json.loads(path.read_text())
+    evals = data.get("evals", [])
+    if eval_id is None:
+        # Flatten across all evals
+        out = []
+        for e in evals:
+            out.extend(e.get("structural_assertions") or [])
+        return out
+    for e in evals:
+        if e.get("id") == eval_id:
+            return e.get("structural_assertions") or []
+    return []
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--spans-dir", required=True, type=Path)
+    p.add_argument("--assertions", required=True, type=Path)
+    p.add_argument("--eval-id", type=int, default=None)
+    p.add_argument("--output", required=True, type=Path)
+    args = p.parse_args()
+
+    assertions = load_assertions(args.assertions, args.eval_id)
+    spans = load_spans(args.spans_dir)
+
+    # Only skip when the eval itself declares no structural requirements
+    # (genuine markdown-skill case). When assertions are declared but no
+    # spans exist, evaluate normally — each assertion fails with clear
+    # evidence. The eval is then incomplete and the skill's quality bar
+    # isn't met. This forces adoption: if you declare structural
+    # requirements, you must wire monocle to satisfy them.
+    if not assertions:
+        result = {
+            "skipped": True,
+            "reason": "no structural_assertions declared for this eval",
+            "summary": {"passed": 0, "failed": 0, "total": 0, "pass_rate": None},
+        }
+    else:
+        results = []
+        for a in assertions:
+            r = evaluate(a, spans)
+            results.append({**a, **r})
+        passed = sum(1 for r in results if r["passed"])
+        total = len(results)
+        result = {
+            "skipped": False,
+            "assertions": results,
+            "summary": {
+                "passed": passed,
+                "failed": total - passed,
+                "total": total,
+                "pass_rate": passed / total if total else None,
+            },
+            "spans_loaded": len(spans),
+        }
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2))
+    print(json.dumps(result, indent=2))
+    return 0 if result.get("skipped") or result["summary"]["failed"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Background

### Why

Eval grading today reads the output file and the transcript. That covers most quality checks — "is the file redacted?", "does the output mention X?".

But some skill quality questions only have answers **inside the running code**:

- **"Was the maintained denylist v3 actually applied to this batch?"** — the cleaned file carries no version stamp.
- **"How many regex matches did the scrubber make?"** — you can count `[REDACTED:*]` tags in the output, but that's *surviving* tags, not the scrubber's authoritative internal counter (overlapping matches, dedup, or pre-filtering can make these differ).
- **"Did the agent call our audited script, or did it inline its own equivalent?"** — if the output looks the same, the file alone can't tell.

These facts live in execution, not in artifacts. NL grading has no channel to read them. Assertions about them in `evals.json` can never pass — the eval has gaps it cannot fill, no matter how thorough the LLM grader is.

[Monocle](https://github.com/monocle2ai/monocle) wraps Python functions and emits OpenTelemetry spans at runtime; the spans carry the missing facts (which denylist version was loaded, how many redactions the scrubber counted internally, when the function started and ended, etc). This PR wires monocle into skill-conductor so authors can declare `structural_assertions` over those spans alongside the existing NL `expectations`. A deterministic grader reads the spans and verifies — no LLM needed.

**Opt-in per skill.** No `monocle.yaml` → no spans → no structural grading → zero overhead. Pure-Markdown skills and skills whose entire value is in the output file are unaffected.

## Summary

NL grading reads transcripts + output files and can't satisfy assertions about internal execution state — policy versions, internal counters, exact call counts. This PR adds an optional structural grading channel: skills declare `structural_assertions` in `evals.json` and ship a tiny `monocle.yaml`; monocle emits spans from the bundled scripts at runtime; a deterministic grader reads them.

## What's in this PR (6 files)

**Shared code (new)**
- `skills/skill-conductor/scripts/monocle_runner.py` — reads `monocle.yaml`, resolves `output_processor: "module:ATTR"` refs, registers `WrapperMethod` objects, threads monocle's file exporter. Imports the target as a real module (not via `runpy`) so wrappers actually fire.
- `skills/skill-conductor/scripts/structural_grader.py` — deterministic grader for `span_present`, `span_count`, `span_attribute`, `span_order`, `no_error_spans`. Strips monocle's `entity.N.*` prefix; coerces numeric strings for numeric comparisons. Returns `skipped:true` only when no assertions are declared (forces adoption when they are).
- `skills/skill-conductor/references/monocle_tracing.md` — author guide. When to use, when NOT to use, accessor contract, troubleshooting.

**Schema + docs (modified, minimum diffs)**
- `skills/skill-conductor/references/schemas.md` — adds `structural_assertions` to the `evals.json` schema with explicit "use ONLY when …" language.
- `skills/skill-conductor/SKILL.md` — one paragraph after the SOP block. Triggers monocle adoption only when the eval needs assertions on internal state; names the don't-use cases.
- `README.md` — new top-level "Structural eval grading (monocle)" section with the test prompt, why monocle, when (not) to use. Eval-infrastructure diagram updated with 4th parallel grader path. Folder tree updated.

## Verification

Verified end-to-end against a `test-skills/pii-scrubber/` skill (not committed — verification scaffolding only). The eval declares `denylist_version == "v3"` and `redacted_count >= 8` as structural assertions:

| Path | NL output checks | Structural grader |
|---|---|---|
| Without monocle (no `MONOCLE_TRACE_OUTPUT_PATH`) | all pass | **1/5** — `denylist_version` and `redacted_count` are unrecoverable from a redacted JSON file |
| With monocle (`MONOCLE_TRACE_OUTPUT_PATH` set, launcher threads it) | all pass | **5/5** — both facts arrive as span attributes |

## When NOT to use (recorded in SKILL.md, schemas.md, monocle_tracing.md, and README)

- Pure-Markdown skills
- Skills where the bundled script is convenience-only (any equivalent code would be equally correct)
- Evals fully expressible via output-file `expectations`

## Test plan

- [ ] Pure-Markdown skill with no `monocle.yaml` → `structural_grader` returns `skipped: true`, exit 0
- [ ] Skill with `monocle.yaml` and `structural_assertions` → all assertions evaluated
- [ ] Skill with `structural_assertions` but missing/empty spans dir → assertions fail (forcing adoption), not silently skip
- [ ] `span_attribute` with `entity.N.*`-prefixed keys resolves correctly
- [ ] Numeric assertions (`>=`, `<=`) work when accessor returns stringified ints